### PR TITLE
Remove npm from codeql workflow

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -24,7 +24,6 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-    - run: npm ci
 
     - uses: github/codeql-action/init@v3
       with:


### PR DESCRIPTION
Apparently it's not needed.

And in case it's needed - setup-node with the correct version should also be necessary