### PR TITLE
Don't reformat code in `dist-check`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,6 @@ jobs:
           node-version: 20.x
 
       - run: npm ci
-      - run: npm run format
       - run: npm run build
 
       - id: diff


### PR DESCRIPTION
Formatting is checked by ESLint (with Prettier plugin).

`dist-check` sole purpose is to verify `ncc build` doesn't change anything.