### PR TITLE
Fix Renovate pinning of GitHub actions one more time

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -4,8 +4,7 @@
   "packageRules": [
     {
       "extends": ["helpers:pinGitHubActionDigests"],
-      "rangeStrategy": "pin",
-      "versioning": "semver-coerced"
+      "versioning": "npm"
     },
     {
       "matchPackageNames": [


### PR DESCRIPTION
Just use "semver with ranges" versioning that rejects shortened versions.